### PR TITLE
fix: made padding the same on top, left, and bottom of episodes

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -913,6 +913,10 @@ div[data-role=controlgroup] a.ui-btn-active {
     padding: 0.25em 0.25em 0.25em 1.5em !important;
 }
 
+[dir="ltr"] .listItem:not(.actionSheetMenuItem)[data-type="Episode"] {
+  padding: .5em 0.25em 0.5em 0.5em !important;
+}
+
 .actionSheetContent {
     padding: .4em !important;
 }


### PR DESCRIPTION
# Description

Title says it all. In my experience, it looks better to have even padding on all sides of an image, especially when the container is so close to the image's size.

Without this change:
![image](https://github.com/user-attachments/assets/ded18e47-68c8-44d7-a467-3a48e0b0f606)


With this change:
![image](https://github.com/user-attachments/assets/8f8ecff1-68ca-4f84-9d1a-716cfcd6731e)


**Note:**
The Episodes page is not responsive for mobile screens, this doesn't have any affect on that

## Type of change

- [x] Bug fix
- [ ] New feature 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**Test Configuration**:
* Jellyfin server version:
* Jellyfin client: Jellyfin Web
* Client browser name and version: Firefox / Chrome
* Device: Desktop PC

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have included relevant comparison screenshots where nececssary
- [ ] I have tested my changes on the TV layout and Default layout of Jellyfin
- [x] I have also tested my changes on multiple devices and screen sizes
