### PR TITLE
chore: added background styling to progress bar in edge

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -1243,12 +1243,13 @@ ul.MuiList-root.MuiMenu-list.MuiList-dense>div:first-child {
 }
 
 progress::-moz-progress-bar,
-progress::-webkit-progress-value {
+::-webkit-progress-value {
     background: var(--btnSubmitBorderColor) !important;
     border-radius: var(--smallRadius) inherit var(--smallRadius) 0;
 }
 
-progress {
+progress,
+::-webkit-progress-bar {
     background: var(--hoverGradient) !important;
     border: solid var(--lighterBorderColor) var(--borderWidth) !important;
     border-radius: var(--smallRadius);


### PR DESCRIPTION
# Description

@lscambo13 This fixes it so the background is properly styled, and based on MDN's docs for [::-webkit-progress-value](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-progress-value) the fill color should work, but it doesn't, so might just be an issue with Edge

# How Has This Been Tested?

Viewing in the Browser

**Test Configuration**:
* Jellyfin server version: 10.10.3
* Jellyfin client: Web
* Client browser name and version: Edge
* Device: PC

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have included relevant comparison screenshots where nececssary
- [ ] I have tested my changes on the TV layout and Default layout of Jellyfin
- [x] I have also tested my changes on multiple devices and screen sizes
