### PR TITLE
New: Style the login page to be more like jellyseerr

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -32,7 +32,7 @@
     --smallRadius: .5em;
     --smallerRadius: .375em;
     --borderWidth: 0.075em;
-    --loginPageBgUrl: "";
+    --loginPageBgUrl: url("");
     --loginPageText: "Sign in to continue";
 }
 
@@ -1387,7 +1387,6 @@ ul.MuiList-root.MuiMenu-list.MuiList-dense>div:first-child {
     padding: 2em 0;
     overflow-y: auto;
     background: 
-        linear-gradient(rgba(45, 55, 72, 0.47) 0%, rgb(26, 32, 46) 100%),
         var(--loginPageBgUrl, linear-gradient(to bottom, var(--darkerGradientPointAlpha), var(--lighterGradientPoint)));
     background-size: cover;
     background-position: center;

--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -32,7 +32,7 @@
     --smallRadius: .5em;
     --smallerRadius: .375em;
     --borderWidth: 0.075em;
-    --loginPageBgUrl: url(https://image.tmdb.org/t/p/original/2meX1nMdScFOoV4370rqHWKmXhY.jpg);
+    --loginPageBgUrl: "";
     --loginPageText: "Sign in to continue";
 }
 
@@ -1386,9 +1386,9 @@ ul.MuiList-root.MuiMenu-list.MuiList-dense>div:first-child {
     min-height: 100vh;
     padding: 2em 0;
     overflow-y: auto;
-    background:
+    background: 
         linear-gradient(rgba(45, 55, 72, 0.47) 0%, rgb(26, 32, 46) 100%),
-        var(--loginPageBgUrl);
+        var(--loginPageBgUrl, linear-gradient(to bottom, var(--darkerGradientPointAlpha), var(--lighterGradientPoint)));
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;

--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -32,6 +32,8 @@
     --smallRadius: .5em;
     --smallerRadius: .375em;
     --borderWidth: 0.075em;
+    --loginPageBgUrl: url(https://image.tmdb.org/t/p/original/2meX1nMdScFOoV4370rqHWKmXhY.jpg);
+    --loginPageText: "Sign in to continue";
 }
 
 html {
@@ -1330,4 +1332,84 @@ ul.MuiList-root.MuiMenu-list.MuiList-dense>div:first-child {
 
 #scenesContent .cardScalable:hover {
     border-color: var(--dimTextColor) !important;
+}
+
+.skinHeader.focuscontainer-x.skinHeader-withBackground.skinHeader-blurred.semiTransparent.noHeaderRight {
+    display: none;
+}
+
+#loginPage {
+    padding-top: 20em !important;
+}
+
+@media (max-height: 890px) {
+    #loginPage {
+        padding-top: 6.5em !important;
+    }
+}
+
+#loginPage .readOnlyContent,
+#loginPage form {
+    max-width: 28em;
+}
+
+#loginPage .readOnlyContent {
+    margin: .5em auto 0em !important;
+}
+
+#loginPage .padded-left.padded-right.padded-bottom-page {
+    margin: 2em auto 0;
+    width: 28em;
+    background: rgba(30, 40, 54, 0.7);
+    padding: 2em 2em 1em 2em !important;
+    border-radius: var(--largerRadius);
+    backdrop-filter: blur(5px);
+    box-sizing: border-box;
+}
+
+@media (max-width: 640px) {
+    #loginPage .readOnlyContent,
+    #loginPage form {
+        max-width: 100%;
+    }
+
+    #loginPage .padded-left.padded-right.padded-bottom-page {
+        width: 100%;
+        margin: 1em auto;
+    }
+}
+
+#loginPage {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    min-height: 100vh;
+    padding: 2em 0;
+    overflow-y: auto;
+    background:
+        linear-gradient(rgba(45, 55, 72, 0.47) 0%, rgb(26, 32, 46) 100%),
+        var(--loginPageBgUrl);
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+.manualLoginForm .sectionTitle {
+    display: none;
+}
+
+.manualLoginForm::before {
+    content: var(--loginPageText);
+    position: relative;
+    display: block;
+    top: -3.5em;
+    margin-bottom: -1em;
+    font-size: 1.875em;
+    font-weight: 800;
+    color: white;
+    text-align: center;
+}
+
+.manualLoginForm {
+    position: relative;
 }

--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -1348,9 +1348,10 @@ ul.MuiList-root.MuiMenu-list.MuiList-dense>div:first-child {
     }
 }
 
-#loginPage .readOnlyContent,
-#loginPage form {
-    max-width: 28em;
+@media (max-height: 1300px) {
+    #loginPage:has(.padded-left.padded-right.padded-bottom-page .visualLoginForm:not(.hide)) {
+        padding-top: 6.5em !important;
+    }
 }
 
 #loginPage .readOnlyContent {
@@ -1367,13 +1368,19 @@ ul.MuiList-root.MuiMenu-list.MuiList-dense>div:first-child {
     box-sizing: border-box;
 }
 
-@media (max-width: 640px) {
-    #loginPage .readOnlyContent,
-    #loginPage form {
-        max-width: 100%;
-    }
+#loginPage .padded-left.padded-right.padded-bottom-page:has(.visualLoginForm:not(.hide)) {
+    width: 80em;
+}
 
+@media (max-width: 640px) {
     #loginPage .padded-left.padded-right.padded-bottom-page {
+        width: 100%;
+        margin: 2em;
+    }
+}
+
+@media (max-width: 1300px) {
+    #loginPage .padded-left.padded-right.padded-bottom-page:has(.visualLoginForm:not(.hide)) {
         width: 100%;
         margin: 2em;
     }
@@ -1386,18 +1393,20 @@ ul.MuiList-root.MuiMenu-list.MuiList-dense>div:first-child {
     min-height: 100vh;
     padding: 2em 0;
     overflow-y: auto;
-    background: 
+    background:
         var(--loginPageBgUrl, linear-gradient(to bottom, var(--darkerGradientPointAlpha), var(--lighterGradientPoint)));
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
 }
 
-.manualLoginForm .sectionTitle {
+.manualLoginForm .sectionTitle,
+.visualLoginForm>h1 {
     display: none;
 }
 
-.manualLoginForm::before {
+.manualLoginForm::before,
+.visualLoginForm::before {
     content: var(--loginPageText);
     position: relative;
     display: block;
@@ -1409,6 +1418,7 @@ ul.MuiList-root.MuiMenu-list.MuiList-dense>div:first-child {
     text-align: center;
 }
 
-.manualLoginForm {
+.manualLoginForm,
+.visualLoginForm {
     position: relative;
 }

--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -1375,7 +1375,7 @@ ul.MuiList-root.MuiMenu-list.MuiList-dense>div:first-child {
 
     #loginPage .padded-left.padded-right.padded-bottom-page {
         width: 100%;
-        margin: 1em auto;
+        margin: 2em;
     }
 }
 


### PR DESCRIPTION
# Description

Styles the login page to be like Jellyseerr. Users can apply loginPageBgUrl variable with there own backdrop image.

## Type of change

- [ ] Bug fix
- [x] New feature 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**Test Configuration**:
* Jellyfin server version: 10.10.3
* Jellyfin client: Jellyfin Web, Android
* Client browser name and version: Chrome / Firefox
* Device: PC, Android

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have included relevant comparison screenshots where nececssary
- [x] I have tested my changes on the TV layout and Default layout of Jellyfin
- [x] I have also tested my changes on multiple devices and screen sizes

# Screenshot
Before
![jf-loginPage](https://github.com/user-attachments/assets/a5b55cc5-a3d4-4ff6-940d-858a1c7f091e)
After
![jf-newLoginPage](https://github.com/user-attachments/assets/97c7809b-89ff-4f97-b7ec-c48cc235fae4)
Android
![js-newMobileLoginPage](https://github.com/user-attachments/assets/ccb5febc-77a2-4d06-8e6c-5579dea17bfb)

