### PR TITLE
update: replace chevron_right with svg

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -1145,12 +1145,15 @@ div[data-role=controlgroup] a.ui-btn-active {
 }
 
 .sectionTitleTextButton>.material-icons::before {
-    border: solid var(--borderWidth);
-    border-radius: var(--largeRadius);
-    font-size: 1em;
-    line-height: unset;
-    font-weight: 600;
-    margin-inline-start: .5em;
+    display: none;
+}
+
+.sectionTitleTextButton>.material-icons.chevron_right {
+    margin-left: .5rem !important;
+    height: 1.5rem;
+    width: 1.5rem;
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke-width='1.5' stroke='%23D1D5DB' aria-hidden='true'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' d='M12.75 15l3-3m0 0l-3-3m3 3h-7.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z'%3E%3C/path%3E%3C/svg%3E") no-repeat center center;
+    background-size: contain; /* Stops miscalculating the size on hover effect */
 }
 
 .toast {


### PR DESCRIPTION
# Description

Small style update to the chevron_right icons in the homepage sections. The current icons look like the Plex logo :(

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [x] New feature 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**Test Configuration**:
* Jellyfin server version: 10.10.3
* Jellyfin client: Jellyfin Web, Android
* Client browser name and version:
* Device: Chrome / Firefox

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have included relevant comparison screenshots where nececssary
- [x] I have tested my changes on the TV layout and Default layout of Jellyfin
- [x] I have also tested my changes on multiple devices and screen sizes

# Screenshot's

Before
![jf-oldChevronRight](https://github.com/user-attachments/assets/e479ea92-2520-4975-b08e-0fe8578d36ec)
After
![jf-chevronRight](https://github.com/user-attachments/assets/7435dbd5-b947-4b51-a182-0abe557a0e7b)
