### PR TITLE
Feat: Styled Additional Dashboard icons & Metadata Save Button

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -474,7 +474,7 @@ html {
 
 .itemProgressBarForeground {
     border-radius: var(--largeRadius);
-    background-color: var(--dimTextColor);
+    background-color: var(--btnSubmitBorderColor);
 }
 
 .backgroundProgress>div {
@@ -596,6 +596,12 @@ progress+span {
     padding: .5em .5em !important;
     margin: 0.125em !important;
     backdrop-filter: blur(.1em);
+}
+
+.btnHeaderSave.button-flat {
+  color: var(--btnSubmitBorderColor) !important;
+  gap: 0.3em;
+  border-radius: var(--smallRadius);
 }
 
 .button-flat:hover {
@@ -942,7 +948,10 @@ div[data-role=controlgroup] a.ui-btn-active {
     border: solid var(--btnDeleteBorderColor) var(--borderWidth);
 }
 
-.listItemIcon.notifications {
+.listItemIcon.notifications,
+.listItemIcon.schedule,
+.listItemIcon.person,
+.listItemIcon.live_tv {
     background-color: rgb(41, 49, 83) !important;
     border: solid var(--borderColor) var(--borderWidth);
 }
@@ -1330,4 +1339,8 @@ ul.MuiList-root.MuiMenu-list.MuiList-dense>div:first-child {
 
 #scenesContent .cardScalable:hover {
     border-color: var(--dimTextColor) !important;
+}
+
+.progressring-spiner {
+  border-color: var(--btnSubmitBorderColor);
 }

--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -474,7 +474,7 @@ html {
 
 .itemProgressBarForeground {
     border-radius: var(--largeRadius);
-    background-color: var(--btnSubmitBorderColor);
+    background-color: var(--dimTextColor);
 }
 
 .backgroundProgress>div {


### PR DESCRIPTION
# Description

Tasks now match the Activity icons
![image](https://github.com/user-attachments/assets/5ce89187-62cc-4ca2-96cc-ebb3257dd85d)

People and Genre icons now also match the Activity icons
![image](https://github.com/user-attachments/assets/883c1610-9cb5-449a-9af3-225cdba1c9fb)

The "Save" button on the editing metadata page now matches the rest of the active colors
![image](https://github.com/user-attachments/assets/24fba48b-4108-4a5b-a071-7bdde032b7b7)


Fixes # (issue)

## Type of change

- [ ] Bug fix
- [x] New feature 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**Test Configuration**:
* Jellyfin server version: 10.10.3
* Jellyfin client: Jellyfin Web
* Client browser name and version: Firefox / Chrome
* Device: PC / iOS

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have included relevant comparison screenshots where nececssary
- [ ] I have tested my changes on the TV layout and Default layout of Jellyfin
- [x] I have also tested my changes on multiple devices and screen sizes
