### PR TITLE
Fix: quickConnect flexbox alignment

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -1451,3 +1451,10 @@ ul.MuiList-root.MuiMenu-list.MuiList-dense>div:first-child {
 .visualLoginForm {
     position: relative;
 }
+
+#quickConnectPreferencesPage .padded-left.padded-right.padded-bottom-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}


### PR DESCRIPTION
# Description

Flexbox alignment, the "Quick Connect" section will visually align with the rest of the user profile pages.

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New feature 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**Test Configuration**:
* Jellyfin server version: 10.10.3
* Jellyfin client: Jellyfin Web, Android
* Client browser name and version: Chrome / Firefox
* Device: PC, Android

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have included relevant comparison screenshots where nececssary
- [ ] I have tested my changes on the TV layout and Default layout of Jellyfin
- [x] I have also tested my changes on multiple devices and screen sizes

# Screenshots
Before
![before](https://github.com/user-attachments/assets/90f68d5f-5c40-4d67-9ad8-e2573da12950)

After
![after](https://github.com/user-attachments/assets/53853eec-f22b-4666-a74e-6436c294e1fd)
![after1](https://github.com/user-attachments/assets/5b5c4ed8-68c8-492d-a82d-784421746f4f)
