### PR TITLE
Fix: progress bar shift

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -1476,3 +1476,8 @@ ul.MuiList-root.MuiMenu-list.MuiList-dense>div:first-child {
 #txtLoginDisclaimer{
     resize: none;
 }
+
+.startTimeText,
+.endTimeText {
+    width: 4em;
+}


### PR DESCRIPTION
# Description

The issue is cause by the [Inter font](https://github.com/lscambo13/ElegantFin/blob/f9e957bd09e0b7c567a49302d7ef741dd8f61abc/Theme/ElegantFin-theme-nightly.css#L40). Without replacing the font, one solution i found was to apply `width` to `.startTimeText, .endTimeText`. Adjust `4em` to accommodate the widest possible time value (-99:99:99).

Fixes #32 

## Type of change

- [x] Bug fix
- [ ] New feature 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

**Test Configuration**:
* Jellyfin server version: 10.10.3
* Jellyfin client: Jellyfin Web, Android
* Client browser name and version: Chrome / Firefox
* Device: PC / Android

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have included relevant comparison screenshots where nececssary
- [ ] I have tested my changes on the TV layout and Default layout of Jellyfin
- [x] I have also tested my changes on multiple devices and screen sizes
