### PR TITLE
Fix: Poster size in media page in TV layout was too small

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -529,6 +529,10 @@ html {
     width: 23vw !important;
 }
 
+.layout-tv .detailImageContainer .card {
+    width: 23vw !important;
+}
+
 @media (max-width: 62.5em) {
     .layout-desktop .itemBackdrop {
         height: 7em !important;
@@ -655,6 +659,11 @@ html {
 .appfooter {
     background-color: var(--headerColor) !important;
     backdrop-filter: var(--blurDefault) !important;
+}
+
+/* Stops header from flickering when scrolling on webOS */
+.layout-tv .skinHeader-blurred:not(.osdHeader){
+    backdrop-filter: none !important;
 }
 
 .headroom--unpinned {

--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -661,11 +661,6 @@ html {
     backdrop-filter: var(--blurDefault) !important;
 }
 
-/* Stops header from flickering when scrolling on webOS */
-.layout-tv .skinHeader-blurred:not(.osdHeader){
-    backdrop-filter: none !important;
-}
-
 .headroom--unpinned {
     -webkit-transform: translateY(-3.5em);
     transform: translateY(-3.5em);


### PR DESCRIPTION
# Description

This pull request includes two CSS fixes to improve the user interface on TV-layout:

1. Updated the poster sizes on the details page by adjusting the width of the cards in the TV layout. 
before: 
![Screenshot 2025-03-29 at 10-42-16 Jellyfin](https://github.com/user-attachments/assets/0b890a98-bba5-46db-9a34-7128434de41e)
after: 
![Screenshot 2025-03-29 at 10-41-30 Jellyfin](https://github.com/user-attachments/assets/6523ec8d-e6be-40e1-a512-4b03bcaf7aaa)

2. Fixed the flickering of the app header on webOS TV.

## Type of change

- [x] Bug fix
- [ ] New feature

# How Has This Been Tested?

- Verifying that the poster sizes on the details page are now consistent and properly scaled.
- Confirming that the flickering of the app header on webOS TV is resolved.
- Comparing before and after images to ensure that the visual improvements are as expected.

**Test Configuration**:
* Jellyfin server version: 10.10.6
* Jellyfin client: Jellyfin Web
* Client browser name and version: JF webOS App, Firefox
* Device: webOS TV, PC

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have included relevant comparison screenshots where necessary
- [x] I have tested my changes on the TV layout and Default layout of Jellyfin
- [x] I have also tested my changes on multiple devices and screen sizes