### PR TITLE
fix: add macos compatible fallback fonts for textarea

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -1890,7 +1890,7 @@ div[data-role=controlgroup] a.ui-btn-active {
 }
 
 .emby-textarea {
-    font-family: consolas;
+    font-family: consolas, monaco, monospace;
 }
 
 .emby-select-withcolor,


### PR DESCRIPTION
# Description
consolas doesn't have great macos support out-of-the-box. I added `monaco` and `monospace` as fallbacks for other users so they can still see a monospaced font.

**Before**
<img width="835" alt="Screenshot 2025-06-09 at 11 38 03 PM" src="https://github.com/user-attachments/assets/72bf01f3-1373-4208-bff6-0cac5f56c7f2" />

**After**
<img width="830" alt="Screenshot 2025-06-09 at 11 40 00 PM" src="https://github.com/user-attachments/assets/e2851c73-dafd-4622-8dc7-4b419c77dad9" />

## Type of change

- [x] Bug fix
- [ ] New feature 

# How Has This Been Tested?

I just modified local CSS on my browser in Chrome and Firefox.

**Test Configuration**:
* Jellyfin server version: 10.10.7
* Jellyfin client: 10.10.7
* Client browser name and version: Chrome
* Device: MacOS

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have included relevant comparison screenshots where nececssary
- [x] I have tested my changes on the TV layout and Default layout of Jellyfin
- [x] I have also tested my changes on multiple devices and screen sizes
