### PR TITLE
Reduce focus scale transform to prevent button overlap

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -213,6 +213,7 @@ html {
 .emby-tabs .emby-button.show-focus:focus {
     background-color: var(--highlightOutlineColor) !important;
     color: #fff !important;
+    transform: scale(1.125) !important;
 }
 
 .emby-tabs .emby-button.show-focus:focus {


### PR DESCRIPTION
## Type of Change

- [x] Bug fix  
- [ ] New feature

## Description

Decreases the scale transform on focused buttons to a smaller value to prevent visual overlap with adjacent elements.

## Screenshots

before: 
<img width="388" height="193" alt="Screenshot 2025-08-10 113830" src="https://github.com/user-attachments/assets/b855862f-0bf1-4b7a-bdaa-a2f5e73c1f78" />
<img width="400" height="144" alt="Screenshot 2025-08-10 113850" src="https://github.com/user-attachments/assets/8e2ca823-ab6a-460d-be66-708ad119f39e" />

after:
<img width="387" height="215" alt="Screenshot 2025-08-10 114023" src="https://github.com/user-attachments/assets/9d0d3c13-7951-40b9-bf0c-db7709cf3763" />
<img width="392" height="107" alt="Screenshot 2025-08-10 114136" src="https://github.com/user-attachments/assets/c623ef88-0d0b-4704-a461-bb928e24f897" />

## Cross-platform Testing

This only impacts the TV layout where button scaling was causing visual overlap. Desktop and mobile layouts are unaffected.

## Test Configuration

- Jellyfin server version:  10.10.7
- Jellyfin client:  Web (TV mode)
- Client browser name and version:  Firefox, WebOs
