### PR TITLE
Ensure Skip Intro Button is readable on jellyfin 10.11

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -2920,6 +2920,7 @@ div[data-role=controlgroup] a.ui-btn-active {
     background-color: whitesmoke;
     box-shadow: var(--shadow);
     margin-right: var(--sidePadding);
+    color: black
 }
 
 /* this allows the skip button get focused correctly on TVs using remote navigation; needs 10.10.7*/


### PR DESCRIPTION
# Pull Request

Thanks for contributing to ElegantFin! Please review the **contributor guidelines** before submitting.

## Type of Change

- [x] Bug fix  
- [ ] New feature

## Description

The skip intro button is not readable on Jellyfin 10.11. This fixed it by making the character black

## Screenshots

Before: 
<img width="370" height="183" alt="image" src="https://github.com/user-attachments/assets/a5ab573f-4a14-4017-b03e-20ef4b6b0756" />

After:
<img width="280" height="133" alt="image" src="https://github.com/user-attachments/assets/423ab72e-d0a1-4a0b-abaa-46f1726db225" />


## Cross-platform Testing

Tested on:
- Jellyfin Web version 10.11.1
- Jellyfin Android version 2.6.3
- Jellyfin on Tizen built on top of 10.11.z branch

## Test Configuration

- Jellyfin server version:  10.11.1
- Jellyfin client:  10.11.1
- Client browser name and version:  Chrome v142.0.7444.59
- Device: Windows
- Other info:

## Checklist

- [x] I performed a self-review of my own code  
- [x] I followed the style conventions (`em` units, minimal media queries).
- [x] I avoided unnecessary use of `!important`.
- [x] I commented my code where applicable.
- [x] I tested my changes on multiple devices, layouts and viewport sizes.
