### PR TITLE
New: FAQ entry for compatibility issues with older Jellyfin servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,12 @@ https://github.com/user-attachments/assets/ac22440d-39d7-48d6-a8da-3b7777372ffd
 - 🤷
 </details>
 
+<details>
+  <summary>8️⃣ - <i>How to fix compatibility issues with older Jellyfin servers?</i></summary>
+
+- If you're experiencing issues like unclickable menu buttons in the Android client on Jellyfin v10.10.7, use an older version of ElegantFin, such as importing the URL: `@import url("https://cdn.jsdelivr.net/gh/lscambo13/ElegantFin@25.08.08/Theme/ElegantFin-jellyfin-theme-build-latest-minified.css");`. Using an older version may resolve other similar compatibility issues.
+</details>
+
 <hr>
 
 ### 📌 Contributing


### PR DESCRIPTION
# Pull Request

Thanks for contributing to ElegantFin! Please review the **contributor guidelines** before submitting.

## Type of Change

- [ ] Bug fix  
- [ ] New feature

## Description

The latest ElegantFin is not fully compatible with older Jellyfin (v10.10.7). 
The upper-left and upper-right menu buttons are not clickable in the Android app, though they work on web pages. 
Using an older version of ElegantFin resolves this issue. 
Updated documentation now offers solutions for issues encountered with older Jellyfin versions.

## Cross-platform Testing
Tested on:
 - Jellyfin Android version 2.6.3
 - Jellyfin Web version 10.10.7

## Test Configuration

- Jellyfin server version:  10.10.7
- Jellyfin client:  Jellyfin Android version 2.6.3
- Client browser name and version:  Microsoft Edge 142.0.3595.53
- Device:
- Other info:

## Checklist

- [x] I performed a self-review of my own code  
- [x] I followed the style conventions (`em` units, minimal media queries).
- [x] I avoided unnecessary use of `!important`.
- [x] I commented my code where applicable.
- [x] I tested my changes on multiple devices, layouts and viewport sizes.
