### PR TITLE
Improve custom media covers

### DIFF
--- a/Theme/assets/add-ons/custom-media-covers-nightly.css
+++ b/Theme/assets/add-ons/custom-media-covers-nightly.css
@@ -53,94 +53,94 @@
 /* These show up when no image is set */
 
 /* div[data-collectiontype="movies"] .cardImageContainer.defaultCardBackground {
-    background: var(--colorOverlayMoviesCover) !important;
+    background-color: var(--colorOverlayMoviesCover) !important;
     background-image: var(--urlMoviesCover) !important;
 }
 
 div[data-collectiontype="tvshows"] .cardImageContainer.defaultCardBackground {
-    background: var(--colorOverlayTvshowsCover) !important;
+    background-color: var(--colorOverlayTvshowsCover) !important;
     background-image: var(--urlTvshowsCover) !important;
 }
 
 div[data-collectiontype="livetv"] .cardImageContainer.defaultCardBackground {
-    background: var(--colorOverlayLivetvCover) !important;
+    background-color: var(--colorOverlayLivetvCover) !important;
     background-image: var(--urlLivetvCover) !important;
 }
 
 div[data-collectiontype="music"] .cardImageContainer.defaultCardBackground {
-    background: var(--colorOverlayMusicCover) !important;
+    background-color: var(--colorOverlayMusicCover) !important;
     background-image: var(--urlMusicCover) !important;
 }
 
 div[data-collectiontype="homevideos"] .cardImageContainer.defaultCardBackground {
-    background: var(--colorOverlayHomevideosCover) !important;
+    background-color: var(--colorOverlayHomevideosCover) !important;
     background-image: var(--urlHomevideosCover) !important;
 }
 
 div[data-collectiontype="books"] .cardImageContainer.defaultCardBackground {
-    background: var(--colorOverlayBooksCover) !important;
+    background-color: var(--colorOverlayBooksCover) !important;
     background-image: var(--urlBooksCover) !important;
 }
 
 div[data-collectiontype="boxsets"] .cardImageContainer.defaultCardBackground {
-    background: var(--colorOverlayBoxsetsCover) !important;
+    background-color: var(--colorOverlayBoxsetsCover) !important;
     background-image: var(--urlBoxsetsCover) !important;
 }
 
 div[data-collectiontype="folders"] .cardImageContainer.defaultCardBackground {
-    background: var(--colorOverlayFoldersCover) !important;
+    background-color: var(--colorOverlayFoldersCover) !important;
     background-image: var(--urlFoldersCover) !important;
 }
 
 div[data-collectiontype="playlists"] .cardImageContainer.defaultCardBackground {
-    background: var(--colorOverlayPlaylistsCover) !important;
+    background-color: var(--colorOverlayPlaylistsCover) !important;
     background-image: var(--urlPlaylistsCover) !important;
 } */
 
 /* These are the front facing images */
 
 div[data-collectiontype="movies"] .cardImageContainer.cardContent {
-    background: var(--colorOverlayMoviesCover) !important;
+    background-color: var(--colorOverlayMoviesCover) !important;
     background-image: var(--urlMoviesCover) !important;
 }
 
 div[data-collectiontype="tvshows"] .cardImageContainer.cardContent {
-    background: var(--colorOverlayTvshowsCover) !important;
+    background-color: var(--colorOverlayTvshowsCover) !important;
     background-image: var(--urlTvshowsCover) !important;
 }
 
 div[data-collectiontype="livetv"] .cardImageContainer.cardContent {
-    background: var(--colorOverlayLivetvCover) !important;
+    background-color: var(--colorOverlayLivetvCover) !important;
     background-image: var(--urlLivetvCover) !important;
 }
 
 div[data-collectiontype="music"] .cardImageContainer.cardContent {
-    background: var(--colorOverlayMusicCover) !important;
+    background-color: var(--colorOverlayMusicCover) !important;
     background-image: var(--urlMusicCover) !important;
 }
 
 div[data-collectiontype="homevideos"] .cardImageContainer.cardContent {
-    background: var(--colorOverlayHomevideosCover) !important;
+    background-color: var(--colorOverlayHomevideosCover) !important;
     background-image: var(--urlHomevideosCover) !important;
 }
 
 div[data-collectiontype="books"] .cardImageContainer.cardContent {
-    background: var(--colorOverlayBooksCover) !important;
+    background-color: var(--colorOverlayBooksCover) !important;
     background-image: var(--urlBooksCover) !important;
 }
 
 div[data-collectiontype="boxsets"] .cardImageContainer.cardContent {
-    background: var(--colorOverlayBoxsetsCover) !important;
+    background-color: var(--colorOverlayBoxsetsCover) !important;
     background-image: var(--urlBoxsetsCover) !important;
 }
 
 div[data-collectiontype="folders"] .cardImageContainer.cardContent {
-    background: var(--colorOverlayFoldersCover) !important;
+    background-color: var(--colorOverlayFoldersCover) !important;
     background-image: var(--urlFoldersCover) !important;
 }
 
 div[data-collectiontype="playlists"] .cardImageContainer.cardContent {
-    background: var(--colorOverlayPlaylistsCover) !important;
+    background-color: var(--colorOverlayPlaylistsCover) !important;
     background-image: var(--urlPlaylistsCover) !important;
 }
 


### PR DESCRIPTION
# Pull Request

## Type of Change

- [X] Bug fix
- [X] Enhancement  
- [ ] New feature

## Description

### Changed
Instead of hard-coding the labels for each collection it now uses the name of the library set in Jellyfin. Hard-coding the label is still supported and works the same as before.

The attribute selector that is used to select the collection cards should be **CollectionFolder**, since we specifically only want to target these. I can't see why we shouldn't be able to **ONLY** use `[data-type="CollectionFolder"]`? - if `data-type` is **CollectionFolder** then `data-isfolder` will always be `true`


**Note:** Personally I think the filter contrast looks better, but it shouldn't be applied when using custom media covers. Furthermore, if applied it should also be applied to the other cards like movies.

### Bug fix
An issue that reset the background scaling and position when setting a custom color.
An issue where the series' would also get the card classes like the contrast filter (See images below).

## Screenshots

### Before
<img width="949" height="208" alt="Before" src="https://github.com/user-attachments/assets/00a5d757-0264-4b2b-a43c-a891d4fd61f5" />

<img width="484" height="397" alt="Before-Series" src="https://github.com/user-attachments/assets/77251a45-c206-4035-bb97-4050b03dc75c" />

### After
There is no difference :)
<img width="949" height="208" alt="After" src="https://github.com/user-attachments/assets/37748312-1404-42df-8c23-494ba9eb9e13" />

The card is darker because it doesn't have the contrast filter applied.
<img width="484" height="397" alt="After-Series" src="https://github.com/user-attachments/assets/ee9952cc-8958-42a2-86a0-74533773f68d" />

## Cross-platform Testing

Changed layout in Display on Web to test TV.
Tested on Android and Web

## Test Configuration

- Jellyfin server version:  10.11.2
- Jellyfin client:  Jellyfin Web 10.11.2, Jellyfin Android 2.6.3 
- Client browser name and version:  Firefox 144.0.2
- Device: Linux, Nothing Phone (2) A065
- Other info:

## Checklist

- [X] I performed a self-review of my own code  
- [X] I followed the style conventions (`em` units, minimal media queries).
- [X] I avoided unnecessary use of `!important`.
- [X] I commented my code where applicable.
- [X] I tested my changes on multiple devices, layouts and viewport sizes.
