### PR TITLE
Fix volume toggle position

### DIFF
--- a/Theme/assets/add-ons/media-bar-plugin-support-nightly.css
+++ b/Theme/assets/add-ons/media-bar-plugin-support-nightly.css
@@ -63,7 +63,7 @@
     background: linear-gradient(0deg, rgba(0, 0, 0, 0.85), 40%, transparent);
 }
 
-.pause-button {
+.pause-button, .volume-toggle {
     top: 1em !important;
 }
 


### PR DESCRIPTION
# Pull Request

## Type of Change

- [x] Bug fix  
- [ ] New feature

## Description

The media bar plugin has trailer support since [version 4.0](https://github.com/MakD/Jellyfin-Media-Bar/releases/tag/v4.0.0). This introduced a new (un-)mute button with the class "volume-toggle". It is currently not positioned correctly (see screenshots below). The change in this pull request applies the pause button's positioning override to it.

## Screenshots

Before:
<img width="341" height="270" alt="before screenshot" src="https://github.com/user-attachments/assets/5e57f81a-ff61-495e-a2d5-86f3492da5f1" />

After:
<img width="341" height="270" alt="after screenshot" src="https://github.com/user-attachments/assets/b74dd3cd-4ba4-40f8-85dd-cc0c2af28e1d" />

## Cross-platform Testing

I tested the changes on my Windows 11 computer  and Android 13 smartphone with different aspect ratios / orientations.

## Test Configuration

- Jellyfin server version: 10.11.6
- Jellyfin client:
  - Jellyfin Web 10.11.6
  - Jellyfin Android 2.6.3
- Client browser name and version:
  - Firefox 148.0 (64 bit)
  - Ecosia 145.1.7632.17 (Chromium 64 bit)
- Device:
  - Desktop: Windows 11 25H2 (64 bit)
  - Mobile: Android 13
- Other info: I also tried the override without `!important`. Though I couldn't find any issues, I left it as it was to be safe. If it should be removed instead, please let me know.

## Checklist

- [x] I performed a self-review of my own code  
- [x] I followed the style conventions (`em` units, minimal media queries).
- [x] I avoided unnecessary use of `!important`.
- [x] I commented my code where applicable.
- [x] I tested my changes on multiple devices, layouts and viewport sizes.
