### PR TITLE
Artist/Band Logo instead of Plain Text name.

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -4116,17 +4116,10 @@ html:not(.layout-mobile)
 /* 2. Hide Title text ONLY for Artists */
 #itemDetailPage:has(.detailImageContainer .cardPadder-square .person) .detailLogo:not(.hide) ~ .detailPageWrapperContainer .nameContainer .itemName,
 #itemDetailPage:has(.detailImageContainer .cardPadder-square .person) .detailLogo:not(.hide) ~ .detailPageWrapperContainer .nameContainer .parentNameLast {
-    display: none ;
+    display: none !important;
 }
 
 /* 3. Layout Cleanup - ONLY for Artists */
 #itemDetailPage:has(.detailImageContainer .cardPadder-square .person) .detailImageContainer {
     display: none ; 
-}
-
-#itemDetailPage:has(.detailImageContainer .cardPadder-square .person) .detailPagePrimaryContainer {
-    display: flex ;
-    flex-direction: column ;
-    align-items: center ;
-    text-align: center ;
 }

--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -1270,7 +1270,7 @@ html.layout-mobile
 html:not(.layout-mobile) 
 #itemDetailPage:has(.detailImageContainer .cardPadder-square:not(.person)) 
 .itemBackdrop {
-    height: calc(100vh - 27vh - var(--primaryItemPageNegativeSpace));
+    height: calc(100vh - 20vh - var(--secondaryItemPageNegativeSpace));
 }
 
 .detailLogo {
@@ -4107,9 +4107,9 @@ html:not(.layout-mobile)
 	display: var(--clearLogoVisibility);
     top: calc(100vh - var(--clearLogoBottomSpace) - var(--primaryItemPageNegativeSpace));
     left: 0;
-    width: 40%;
-    transform: translateY(-100%);
-    margin: auto 30%;
+    width: 20%;
+    transform: translateY(-225%);
+    margin: auto 40%;
     height: 25vh;
     background-position: bottom;
 }

--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -4098,6 +4098,7 @@ for extended styling, use the add-on */
 /* basic styling for the Media Bar Plugin - end */
 
 /* Showing Artists Logos instead of Title text - start */
+
 /* 1. Only trigger if it's an Artist (usually square) vs an Actor (usually portrait) */
 /* This specifically protects Actor portrait cards from being hidden */
 html:not(.layout-mobile) 
@@ -4113,13 +4114,14 @@ html:not(.layout-mobile)
     background-position: bottom;
 }
 
-/* 2. Hide Title text ONLY for Artists */
+/* 2. Hide Title text if there is a logo - ONLY for Artists */
 #itemDetailPage:has(.detailImageContainer .cardPadder-square .person) .detailLogo:not(.hide) ~ .detailPageWrapperContainer .nameContainer .itemName,
 #itemDetailPage:has(.detailImageContainer .cardPadder-square .person) .detailLogo:not(.hide) ~ .detailPageWrapperContainer .nameContainer .parentNameLast {
     display: none !important;
 }
 
-/* 3. Layout Cleanup - ONLY for Artists */
+/* 3. Hide Image Container - ONLY for Artists */
 #itemDetailPage:has(.detailImageContainer .cardPadder-square .person) .detailImageContainer {
     display: none ; 
 }
+/* Showing Artists Logos instead of Title text - end */

--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -1261,8 +1261,16 @@ body {
     height: calc(100vh - 27vh - var(--secondaryItemPageNegativeSpace));
 }
 
-#itemDetailPage:has(.detailImageContainer .cardPadder-square:not(.person)) .itemBackdrop {
-    height: calc(100vh - 20vh - var(--secondaryItemPageNegativeSpace));
+html.layout-mobile 
+#itemDetailPage:has(.detailImageContainer .cardPadder-square:not(.person)) 
+.itemBackdrop {
+    height: 45vh;
+}
+
+html:not(.layout-mobile) 
+#itemDetailPage:has(.detailImageContainer .cardPadder-square:not(.person)) 
+.itemBackdrop {
+    height: calc(100vh - 27vh - var(--primaryItemPageNegativeSpace));
 }
 
 .detailLogo {
@@ -1382,8 +1390,7 @@ body {
 
 /* this hides the detail logo  when media card is visible */
 #itemDetailPage:has(.detailImageContainer .backdropCard) .detailLogo,
-#itemDetailPage:has(.detailImageContainer .album) .detailLogo,
-#itemDetailPage:has(.detailImageContainer .person) .detailLogo {
+#itemDetailPage:has(.detailImageContainer .album) .detailLogo {
     z-index: 2;
     display: none;
 }
@@ -4089,3 +4096,37 @@ for extended styling, use the add-on */
 }
 
 /* basic styling for the Media Bar Plugin - end */
+
+/* Showing Artists Logos instead of Title text - start */
+/* 1. Only trigger if it's an Artist (usually square) vs an Actor (usually portrait) */
+/* This specifically protects Actor portrait cards from being hidden */
+html:not(.layout-mobile) 
+#itemDetailPage:has(.detailImageContainer .cardPadder-square .person) 
+.detailLogo {
+	display: var(--clearLogoVisibility);
+    top: calc(100vh - var(--clearLogoBottomSpace) - var(--primaryItemPageNegativeSpace));
+    left: 0;
+    width: 40%;
+    transform: translateY(-100%);
+    margin: auto 30%;
+    height: 25vh;
+    background-position: bottom;
+}
+
+/* 2. Hide Title text ONLY for Artists */
+#itemDetailPage:has(.detailImageContainer .cardPadder-square .person) .detailLogo:not(.hide) ~ .detailPageWrapperContainer .nameContainer .itemName,
+#itemDetailPage:has(.detailImageContainer .cardPadder-square .person) .detailLogo:not(.hide) ~ .detailPageWrapperContainer .nameContainer .parentNameLast {
+    display: none ;
+}
+
+/* 3. Layout Cleanup - ONLY for Artists */
+#itemDetailPage:has(.detailImageContainer .cardPadder-square .person) .detailImageContainer {
+    display: none ; 
+}
+
+#itemDetailPage:has(.detailImageContainer .cardPadder-square .person) .detailPagePrimaryContainer {
+    display: flex ;
+    flex-direction: column ;
+    align-items: center ;
+    text-align: center ;
+}


### PR DESCRIPTION
## Type of Change

- [ ] Bug fix  
- [x] New feature

## Description

Artists' pages now show their logos instead of the artist/band name in plain text ( if the logo is available )

## Screenshots
Before:
<img width="1885" height="906" alt="Screenshot 2026-03-30 004212" src="https://github.com/user-attachments/assets/4a9a02f5-b2d4-4c83-b726-b06e9655f846" />

After:
<img width="1887" height="926" alt="Screenshot 2026-03-30 004252" src="https://github.com/user-attachments/assets/efa86348-2f35-4107-8616-6eccbbbfa456" />

## Cross-platform Testing

Testing of the Ui was done over a normal computer screen, a phone, and a 43-inch 4K TV, over all other pages too (movie, actor), to make sure no conflicts happened

## Test Configuration

- Jellyfin server version:  10.11.6
- Jellyfin client:  Jellyfin Web 10.11.6, Jellyfin Android 2.6.3
- Client browser name and version:  Chrome Jellyfin Web 10.11.6
- Device: Windows, Android

## Checklist

- [x] I performed a self-review of my own code  
- [x] I followed the style conventions (`em` units, minimal media queries).
- [x] I avoided unnecessary use of `!important`.
- [x] I commented my code where applicable.
- [x] I tested my changes on multiple devices, layouts and viewport sizes.
