### PR TITLE
Fix: season selector full-width and expanded episodes grid layout

### DIFF
--- a/Theme/ElegantFin-theme-v25.12.31.css
+++ b/Theme/ElegantFin-theme-v25.12.31.css
@@ -4049,4 +4049,30 @@ for extended styling, use the add-on */
     color: black;
 }
 
+/* Fix: Series episodes section - season selector full-width + expanded grid layout */
+.series-episodes-section .sectionTitleContainer {
+  width: 100%;
+  box-sizing: border-box;
+}
+.series-episodes-section .sectionTitle-link.sectionTitleTextButton {
+  flex: 1;
+  min-width: 0;
+}
+.series-episodes-section .itemsContainer.vertical-wrap,
+.series-episodes-section .scrollSlider.vertical-wrap {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  white-space: normal !important;
+  transform: none !important;
+  width: 100% !important;
+}
+.series-episodes-section .itemsContainer.vertical-wrap .card,
+.series-episodes-section .scrollSlider.vertical-wrap .card {
+  flex: 0 0 var(--cardWidth) !important;
+  width: var(--cardWidth) !important;
+}
+.series-episodes-section.emby-scroller-container {
+  overflow: visible !important;
+}
+
 /* basic styling for the Media Bar Plugin - end */


### PR DESCRIPTION
Adds CSS rules scoped to .series-episodes-section to fix two issues:
- Season selector bar not stretching full width on series detail page
- Expanded episodes view stacking vertically instead of showing as grid

# Pull Request

Thanks for contributing to ElegantFin! Please review the **contributor guidelines** before submitting.

## Type of Change

- [X] Bug fix  

## Description

Two layout issues occur on the series detail page when using the series-episodes-section:

Issue 1 — Season selector not full-width:
The sectionTitleContainer inside .series-episodes-section has no width: 100%, causing the season title and "Select Season" button to stay left-aligned instead of stretching across the full page width.

Issue 2 — Expanded episodes stack vertically instead of grid:
When Jellyfin switches to the expanded (show-all) view, the itemsContainer receives the .vertical-wrap class. ElegantFin only applies justify-content: flex-start to .vertical-wrap, but does not set flex-wrap: wrap. This causes all episode cards to stack in a single vertical column instead of wrapping into a grid.

Fix:
Added scoped CSS rules at the end of the stylesheet, targeting only .series-episodes-section to avoid side effects on other parts of the theme. The expanded grid reuses ElegantFin's existing --cardWidth variable so card sizing stays consistent with the rest of the theme.

## Screenshots

Here you see that width is broken with original, the width is fixed with my fix. (Only works for web version. ios app is not fixed)
<img width="2523" height="1182" alt="ElegantFin-broken-selector" src="https://github.com/user-attachments/assets/2ae298fa-986d-4e72-bfe3-db8d5f758611" />
<img width="2522" height="1188" alt="ElegantFin-fixed-selector" src="https://github.com/user-attachments/assets/9084a889-e075-4e60-969c-a5e2d7c9a521" />

## Cross-platform Testing

I have not tested multiple devices. These fixes have been verified on desktop web (Chromium
The iOS native app still exhibits the same layout issues.

## Test Configuration

- Jellyfin server version:  10.11.8
- Jellyfin client:  Webversion
- Client browser name and version:  [Brave 1.89.143 (Official Build) (64-bit)](https://brave.com/latest/), Chromium: 147.0.7727.117
- Device: PC
- Other info: ElegentFin version 25.12.31

## Checklist

- [X] I performed a self-review of my own code  (with the help of ai to verify and understand the created code)
- [ ] I followed the style conventions (`em` units, minimal media queries).
- [X] I avoided unnecessary use of `!important`.
- [X] I commented my code where applicable.
- [ ] I tested my changes on multiple devices, layouts and viewport sizes.
