### PR TITLE
[Merged] Improve arrlinks hover

### DIFF
--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -1930,6 +1930,7 @@ progress + span {
 
 .itemExternalLinks.focuscontainer-x > .button-link {
     color: var(--textColor);
+    background-color: var(--selectorBackgroundColor);
     padding: 0.125em 0.5em;
     border-radius: var(--smallerRadius);
     margin-bottom: 0.5em;

--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -1982,6 +1982,30 @@ progress + span {
     color: var(--textColor) !important;
 }
 
+.layout-desktop .itemExternalLinks.focuscontainer-x > a[href*="letterboxd.com"]:hover,
+.itemExternalLinks.focuscontainer-x > a[href*="letterboxd.com"]:active {
+    background-color: rgb(0, 0, 0) !important;
+    color: var(--textColor) !important;
+}
+
+.layout-desktop .itemExternalLinks.focuscontainer-x > a[title*="Radarr"]:hover,
+.itemExternalLinks.focuscontainer-x > a[title*="Radarr"]:active {
+    background-color: rgb(255, 194, 48) !important;
+    color: var(--textColor) !important;
+}
+
+.layout-desktop .itemExternalLinks.focuscontainer-x > a[title*="Sonarr"]:hover,
+.itemExternalLinks.focuscontainer-x > a[title*="Sonarr"]:active {
+    background-color: rgb(7, 186, 233) !important;
+    color: var(--textColor) !important;
+}
+
+.layout-desktop .itemExternalLinks.focuscontainer-x > a[title*="Bazarr"]:hover,
+.itemExternalLinks.focuscontainer-x > a[title*="Bazarr"]:active {
+    background-color: rgb(0, 0, 0) !important;
+    color: var(--textColor) !important;
+}
+
 .itemTags,
 .itemTags > a {
     display: none;

--- a/Theme/ElegantFin-theme-nightly.css
+++ b/Theme/ElegantFin-theme-nightly.css
@@ -1930,7 +1930,6 @@ progress + span {
 
 .itemExternalLinks.focuscontainer-x > .button-link {
     color: var(--textColor);
-    background-color: var(--selectorBackgroundColor);
     padding: 0.125em 0.5em;
     border-radius: var(--smallerRadius);
     margin-bottom: 0.5em;


### PR DESCRIPTION
# Pull Request

Thanks for contributing to ElegantFin! Please review the **contributor guidelines** before submitting.

## Type of Change

- [ ] Bug fix  
- [ x ] New feature

## Description

Jellyfin Enhanced adds extra links to letterbox, sonarr, radarr and bazarr (if the user so pleases). I noticed these had the default hover color (Jellyfin pink) so i looked into it and added more proper looking hover colors.

## Screenshots

This is where the user configures and enables the functionality (for reference)
<img width="1671" height="1095" alt="image" src="https://github.com/user-attachments/assets/3da8eeda-4980-4d90-ac6f-c56c0aa6b6d8" />

Before pics:

(Shows this for reference how it's done for the TMDB)
<img width="290" height="58" alt="image" src="https://github.com/user-attachments/assets/a4e22a03-cffd-42a5-af4e-d0f00826b8df" />

<img width="285" height="43" alt="image" src="https://github.com/user-attachments/assets/374f123f-0ebf-4f3d-b8a5-f64d2448a381" />

<img width="294" height="46" alt="image" src="https://github.com/user-attachments/assets/9ccf5c30-b8f2-472e-9311-0b4883570a22" />

<img width="300" height="50" alt="image" src="https://github.com/user-attachments/assets/49172679-f021-4a5d-8d16-872dfa9a484a" />

After pics:

<img width="296" height="28" alt="image" src="https://github.com/user-attachments/assets/c6eba86c-e9d7-4284-bfef-747e1230a2f6" />

<img width="288" height="46" alt="image" src="https://github.com/user-attachments/assets/957e074a-e114-4347-b7d1-287f94aae323" />


<img width="296" height="52" alt="image" src="https://github.com/user-attachments/assets/98769ac6-6552-4dc2-83c5-0a1622db22e8" />


## Cross-platform Testing

IOS (just showing for radarr, it's the same way applied like the other links)
<img width="1179" height="2334" alt="20260607_203120000_iOS" src="https://github.com/user-attachments/assets/1e505700-0041-4ca4-bb9a-4448b57c8a16" />


Also tested in TV mode on my desktop, but there's no links displayed (as expected)
Also tested in Mobile mode on my desktop: 
<img width="314" height="49" alt="image" src="https://github.com/user-attachments/assets/ca5e8cfc-d395-452a-96ce-7ac392ea5145" />


## Test Configuration

- Jellyfin server version:  10.11.11
- Jellyfin client:  Web
- Client browser name and version:  Chrome 148.0.7778.218
- Device: Desktop Windows 11, iOS 26.5 iPhone 16.
- Other info: While the screenshots show no background by default, this change has been removed from this seperate branch!

## Checklist

- [ x ] I performed a self-review of my own code  
- [ x ] I followed the style conventions (`em` units, minimal media queries).
- [ x ] I avoided unnecessary use of `!important`.
- [ x ] I commented my code where applicable.
- [ x ] I tested my changes on multiple devices, layouts and viewport sizes.
